### PR TITLE
[develop] 투표 페이지 UI 개선

### DIFF
--- a/src/components/atoms/NavBox.tsx
+++ b/src/components/atoms/NavBox.tsx
@@ -44,7 +44,7 @@ const NavBox = ({ title, link, isSide }: NavBoxPropType) => {
           },
           '@media(max-width:991px)': isSide
             ? { margin: '0px', padding: '0px', height: '24px' }
-            : { margin: '0px 6px', padding: '0px 6px' },
+            : { margin: '0px 5px', padding: '0px 2px' },
         }}
       >
         {title}

--- a/src/components/atoms/NavBox.tsx
+++ b/src/components/atoms/NavBox.tsx
@@ -34,7 +34,7 @@ const NavBox = ({ title, link, isSide }: NavBoxPropType) => {
           margin: '0px 8px',
           padding: '0px 8px',
           textAlign: 'center',
-          lineHeight: '32px',
+          // lineHeight: '32px',
           alignItems: 'center',
           textDecoration: 'none',
           transition: 'color 0.5s',

--- a/src/components/atoms/NavBox.tsx
+++ b/src/components/atoms/NavBox.tsx
@@ -34,7 +34,6 @@ const NavBox = ({ title, link, isSide }: NavBoxPropType) => {
           margin: '0px 8px',
           padding: '0px 8px',
           textAlign: 'center',
-          // lineHeight: '32px',
           alignItems: 'center',
           textDecoration: 'none',
           transition: 'color 0.5s',

--- a/src/components/molecules/LanguageBox.tsx
+++ b/src/components/molecules/LanguageBox.tsx
@@ -42,11 +42,11 @@ const LanguageBox = ({ language, isVotePage }: { language: string; isVotePage: b
       <div
         onTouchStart={handleTouchStart}
         css={{
+          height: '32px',
           display: 'flex',
           margin: '0px 8px',
           padding: '0px 8px',
           textAlign: 'center',
-          lineHeight: '32px',
           alignItems: 'center',
           cursor: 'pointer',
           '@media(max-width:991px)': {

--- a/src/components/molecules/NavBar.tsx
+++ b/src/components/molecules/NavBar.tsx
@@ -10,7 +10,7 @@ const NavBar = ({ texts }: { texts: NavBarTextType }) => {
   const { setIsSideBarOpen } = useContext(SideBarContext) as SideBarContextType;
   const router = useRouter();
   const page = router.pathname.split('/')[2];
-  const isVotePage = page === 'votes';
+  const isVotePage = page === 'votes' || page === 'voteDetail';
   const isLoginSignUpPage = page === 'login' || page === 'signUp';
 
   return (

--- a/src/components/molecules/NavContainer.tsx
+++ b/src/components/molecules/NavContainer.tsx
@@ -13,7 +13,7 @@ const NavContainer = ({ texts, isVotePage }: { texts: NavBarTextType; isVotePage
         flexShrink: '1',
       }}
     >
-      <ul css={{ padding: '10px', '@media(max-width:991px)': { padding: '7px' } }}>
+      <ul css={{ padding: '10px', '@media(max-width:991px)': { padding: '5px' } }}>
         <NavBox title={texts.vote} link={texts.link.vote} />
         {/* <PageBox title={texts.community} link={texts.link.community} /> */}
       </ul>
@@ -23,7 +23,7 @@ const NavContainer = ({ texts, isVotePage }: { texts: NavBarTextType; isVotePage
             padding: '10px',
             display: 'flex',
             alignItems: 'center',
-            '@media(max-width:991px)': { padding: '7px' },
+            '@media(max-width:991px)': { padding: '5px' },
           }}
         >
           <LanguageBox language={texts.language} isVotePage={true} />
@@ -34,7 +34,7 @@ const NavContainer = ({ texts, isVotePage }: { texts: NavBarTextType; isVotePage
             padding: '10px',
             display: 'flex',
             alignItems: 'center',
-            '@media(max-width:991px)': { padding: '7px', display: 'none' },
+            '@media(max-width:991px)': { padding: '5px', display: 'none' },
           }}
         >
           <NavBox title={texts.aboutUs} link={texts.link.aboutUs} isSide />

--- a/src/components/molecules/NavContainer.tsx
+++ b/src/components/molecules/NavContainer.tsx
@@ -18,12 +18,24 @@ const NavContainer = ({ texts, isVotePage }: { texts: NavBarTextType; isVotePage
         {/* <PageBox title={texts.community} link={texts.link.community} /> */}
       </ul>
       {isVotePage ? (
-        <ul css={{ padding: '10px', '@media(max-width:991px)': { padding: '7px' } }}>
+        <ul
+          css={{
+            padding: '10px',
+            display: 'flex',
+            alignItems: 'center',
+            '@media(max-width:991px)': { padding: '7px' },
+          }}
+        >
           <LanguageBox language={texts.language} isVotePage={true} />
         </ul>
       ) : (
         <ul
-          css={{ padding: '10px', '@media(max-width:991px)': { padding: '7px', display: 'none' } }}
+          css={{
+            padding: '10px',
+            display: 'flex',
+            alignItems: 'center',
+            '@media(max-width:991px)': { padding: '7px', display: 'none' },
+          }}
         >
           <NavBox title={texts.aboutUs} link={texts.link.aboutUs} isSide />
           {texts.recruit && (

--- a/src/components/organisms/voteDetail/VoteDetailInfo.tsx
+++ b/src/components/organisms/voteDetail/VoteDetailInfo.tsx
@@ -47,21 +47,21 @@ const VoteDetailInfo = ({ voteDetailInfo, ...props }: VoteDetailInfoProps) => {
           {secondRankStar?.STAR_NAME}
         </RankProfile>
       </Stack>
-      <UnstyledButton
-        css={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: 60,
-          borderRadius: '10px',
-          background: '#FCEEEE',
-          color: '#FC5280',
-          fontSize: '17px',
-          fontWeight: 600,
-          margin: '0 auto 40px auto',
-        }}
-      >
-        {voteDetailInfo.LINK !== '' ? (
+      {voteDetailInfo.LINK !== '' && (
+        <UnstyledButton
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            height: 60,
+            borderRadius: '10px',
+            background: '#FCEEEE',
+            color: '#FC5280',
+            fontSize: '17px',
+            fontWeight: 600,
+            margin: '0 auto 40px auto',
+          }}
+        >
           <Link
             href={voteDetailInfo.LINK}
             target="_blank"
@@ -84,13 +84,8 @@ const VoteDetailInfo = ({ voteDetailInfo, ...props }: VoteDetailInfoProps) => {
               <Image width={24} height={24} src="/icons/icon_pinkArrow.svg" alt="arrow" />
             </Center>
           </Link>
-        ) : (
-          <Center px={50}>
-            {voteDetailLanguage?.seeMore}
-            <Image width={24} height={24} src="/icons/icon_pinkArrow.svg" alt="arrow" />
-          </Center>
-        )}
-      </UnstyledButton>
+        </UnstyledButton>
+      )}
     </div>
   );
 };

--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -169,8 +169,8 @@ export const Votes_Text_en = {
   voteEnd: 'Until the end',
   tab: {
     all: 'ALL',
-    bday: 'B-day Vote',
-    league: 'League Vote',
+    bday: 'B-day',
+    league: 'League',
   },
   winner: '1st',
   daysAgo: 'd',

--- a/src/texts/es.ts
+++ b/src/texts/es.ts
@@ -169,8 +169,8 @@ export const Votes_Text_es = {
   voteEnd: 'Termina en',
   tab: {
     all: 'ALL',
-    bday: 'B-day Vote',
-    league: 'League Vote',
+    bday: 'B-day',
+    league: 'League',
   },
   winner: 'Primer puesto',
   daysAgo: 'Día',

--- a/src/texts/in.ts
+++ b/src/texts/in.ts
@@ -169,8 +169,8 @@ export const Votes_Text_in = {
   voteEnd: 'Sampai akhir',
   tab: {
     all: 'ALL',
-    bday: 'B-day Vote',
-    league: 'League Vote',
+    bday: 'B-day',
+    league: 'League',
   },
   winner: '1st',
   daysAgo: 'd',

--- a/src/texts/ja.ts
+++ b/src/texts/ja.ts
@@ -169,8 +169,8 @@ export const Votes_Text_ja = {
   voteEnd: '最後まで',
   tab: {
     all: 'ALL',
-    bday: 'B-day Vote',
-    league: 'League Vote',
+    bday: '誕生日 投票',
+    league: 'リーグ 投票',
   },
   winner: '1位',
   daysAgo: '日々',

--- a/src/texts/vi.ts
+++ b/src/texts/vi.ts
@@ -169,8 +169,8 @@ export const Votes_Text_vi = {
   voteEnd: 'Cho đến khi kết thúc',
   tab: {
     all: 'ALL',
-    bday: 'B-day Vote',
-    league: 'League Vote',
+    bday: 'B-day',
+    league: 'League',
   },
   winner: '1st',
   daysAgo: 'ngày',


### PR DESCRIPTION
https://www.notion.so/UI-web-bceef74a522642ad8411d3a2769a1fdf
1. 생일 기념일 아이돌 팬투표 자세히 알아보기 제거 (상세 내용이 없는 경우)
2. 일본어ver 일 때,  투표 페이지 정렬 탭 바: 영어 -> 일본어로 변경
3. 인도네시아ver 일 때,  상단 navBar 줄간격 변경 및 투표 페이지 정렬 탭 바 문구 수정
4. 투표상세페이지에서 navBar 변경