### PR TITLE
[develop] fix: 투표 예정인 voteListItem은 VoteHighRankTab을 호출하지 않도록 변경

### DIFF
--- a/src/components/organisms/VoteListItem.tsx
+++ b/src/components/organisms/VoteListItem.tsx
@@ -44,13 +44,13 @@ const VoteListItem = ({ startDay, endDay, voteData, ...props }: VoteListItemProp
   const VoteHighRankTabProps: VoteHighRankTabProps = {
     status: voteData.STATUS as VoteStatus,
     stars: {
-      firstRankStarName: voteData.FIRST_RANK_STAR_INFO.STAR_NAME,
-      secondRankStarName: voteData.SECOND_RANK_STAR_INFO.STAR_NAME,
+      firstRankStarName: voteData?.FIRST_RANK_STAR_INFO?.STAR_NAME,
+      secondRankStarName: voteData?.SECOND_RANK_STAR_INFO?.STAR_NAME,
     },
     votes: {
       voteDiff:
-        parseInt(voteData.FIRST_RANK_STAR_INFO.VOTE_CNT) -
-        parseInt(voteData.SECOND_RANK_STAR_INFO.VOTE_CNT),
+        parseInt(voteData?.FIRST_RANK_STAR_INFO?.VOTE_CNT) -
+        parseInt(voteData?.SECOND_RANK_STAR_INFO?.VOTE_CNT),
       voteDiffFront: voteDetailText?.voteDifference.front as string,
       voteDiffBack: voteDetailText?.voteDifference.back as string,
       voteResult: voteDetailText?.voteResult as string,
@@ -101,14 +101,16 @@ const VoteListItem = ({ startDay, endDay, voteData, ...props }: VoteListItemProp
       >
         {voteData.TITLE}
       </div>
-      <Link
-        href={{
-          pathname: `/${language}/voteDetail`,
-          query: { vote_IDX: voteData.VOTE_IDX, lang: voteDetailLanguage },
-        }}
-      >
-        <VoteHighRankTab {...VoteHighRankTabProps} />
-      </Link>
+      {voteData.STATUS !== 'R' && (
+        <Link
+          href={{
+            pathname: `/${language}/voteDetail`,
+            query: { vote_IDX: voteData.VOTE_IDX, lang: voteDetailLanguage },
+          }}
+        >
+          <VoteHighRankTab {...VoteHighRankTabProps} />
+        </Link>
+      )}
       <div
         css={{
           display: 'none',


### PR DESCRIPTION
투표 예정인 아이템에 대하여 후보자를 등록하지 않았을 시 값이 없어 error 가 발생했습니다.
따라서 투표 예정인 항목은 1, 2위 정보창 Component를 호출하지 않게 하고,
1, 2위 정보가 undefined인 case를 추가하였습니다.
approve 되면 바로 실서버까지 배포하겠습니다