### PR TITLE
[feat/community] 게시물, 최근 방문 게시판 없을 경우 화면 작업 완료

### DIFF
--- a/src/components/atoms/GradientButton.tsx
+++ b/src/components/atoms/GradientButton.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+type OwnPropType = {
+  text: string;
+  onClick?: () => void;
+  minWidth?: React.CSSProperties['minWidth'];
+  minHeight?: React.CSSProperties['height'];
+  margin?: React.CSSProperties['margin'];
+  fontSize?: React.CSSProperties['fontSize'];
+  fontWeight?: React.CSSProperties['fontWeight'];
+};
+
+const GradientButton = ({
+  text,
+  onClick,
+  minWidth,
+  minHeight,
+  margin,
+  fontSize,
+  fontWeight,
+}: OwnPropType) => {
+  return (
+    <div
+      css={{
+        minWidth: minWidth || '132px',
+        minHeight: minHeight || '48px',
+        margin: margin || '30px 0px 0px',
+        padding: '5px 20px',
+        borderRadius: '12px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: fontSize || '20px',
+        fontWeight: fontWeight,
+        color: '#fff',
+        textAlign: 'center',
+        backgroundImage: 'linear-gradient(104deg, #ff5656 7.74%, #ef30ba 96.35%)',
+        cursor: 'pointer',
+      }}
+      onClick={onClick}
+    >
+      {text}
+    </div>
+  );
+};
+
+export default GradientButton;

--- a/src/components/atoms/Language.tsx
+++ b/src/components/atoms/Language.tsx
@@ -51,7 +51,7 @@ const Language = ({ language, langCookie }: PropType) => {
         }}
         onClick={() => {
           setLangCookie(langCookie);
-          router.push(href);
+          router.replace(href);
         }}
       >
         {language}

--- a/src/components/modals/CommunityLanguageModal.tsx
+++ b/src/components/modals/CommunityLanguageModal.tsx
@@ -60,7 +60,7 @@ const CommunityLanguageModal = ({
   const router = useRouter();
   const onClickLanguageBox = (language: BackLangType | 'ALL') => {
     setBoardLanguage(language);
-    router.push({
+    router.replace({
       pathname: router.pathname,
       query: { ...router.query, boardLang: language, page: 1 },
     });

--- a/src/components/molecules/CommunityBoardArticle.tsx
+++ b/src/components/molecules/CommunityBoardArticle.tsx
@@ -3,9 +3,6 @@ import type { PostListItemType } from '@/types/community';
 import IconPopular from '../atoms/IconPopular';
 import { CommunityBoardTextType } from '@/types/textTypes';
 import { formatWrittenTime, timeType } from '@/utils/util';
-import { text } from 'stream/consumers';
-
-// TODO: 작성 시간 변환하는 로직 추가 필요~
 
 type OwnPropType = {
   postItem: PostListItemType;

--- a/src/components/molecules/CommunityBoardLangSelector.tsx
+++ b/src/components/molecules/CommunityBoardLangSelector.tsx
@@ -1,0 +1,27 @@
+import IconArrowDown from '../atoms/IconArrowDown';
+import IconFilter from '../atoms/IconFilter';
+
+type OwnPropType = {
+  onClick: () => void;
+  language: string;
+};
+
+const CommunityBoardLangSelector = ({ onClick, language }: OwnPropType) => {
+  return (
+    <div
+      css={{
+        cursor: 'pointer',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+      onClick={onClick}
+    >
+      <IconFilter />
+      <span css={{ margin: '0px 5px' }}>{language}</span>
+      <IconArrowDown width="11" height="6" strokeWidth="3" />
+    </div>
+  );
+};
+
+export default CommunityBoardLangSelector;

--- a/src/components/molecules/CommunityBoardTopNavi.tsx
+++ b/src/components/molecules/CommunityBoardTopNavi.tsx
@@ -1,22 +1,18 @@
 import { useRouter } from 'next/router';
 import IconArrowLeft from '../atoms/IconArrowLeft';
-import IconFilter from '../atoms/IconFilter';
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, ReactNode, SetStateAction } from 'react';
+import CommunityBoardLangSelector from './CommunityBoardLangSelector';
 
 export type CommunityBoardTopNaviPropType = {
   backLink: string;
   boardTitle: string;
-  withLang: boolean;
-  language: string;
-  setLangModal: Dispatch<SetStateAction<boolean>>;
+  langSelector?: ReactNode;
 };
 
 const CommunityBoardTopNavi = ({
   backLink,
   boardTitle,
-  withLang,
-  language,
-  setLangModal,
+  langSelector,
 }: CommunityBoardTopNaviPropType) => {
   const router = useRouter();
 
@@ -37,20 +33,7 @@ const CommunityBoardTopNavi = ({
           />
           <h2>{boardTitle}</h2>
         </div>
-        {withLang && (
-          <div
-            css={{
-              cursor: 'pointer',
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}
-            onClick={() => setLangModal(true)}
-          >
-            <IconFilter />
-            <span css={{ margin: '0px 5px' }}>{language}</span>
-          </div>
-        )}
+        {langSelector}
       </div>
     </>
   );

--- a/src/components/molecules/CommunityBoardTopNavi.tsx
+++ b/src/components/molecules/CommunityBoardTopNavi.tsx
@@ -1,19 +1,13 @@
 import { useRouter } from 'next/router';
 import IconArrowLeft from '../atoms/IconArrowLeft';
-import { Dispatch, ReactNode, SetStateAction } from 'react';
-import CommunityBoardLangSelector from './CommunityBoardLangSelector';
+import { ReactNode } from 'react';
 
 export type CommunityBoardTopNaviPropType = {
-  backLink: string;
   boardTitle: string;
-  langSelector?: ReactNode;
+  rightItem?: ReactNode;
 };
 
-const CommunityBoardTopNavi = ({
-  backLink,
-  boardTitle,
-  langSelector,
-}: CommunityBoardTopNaviPropType) => {
+const CommunityBoardTopNavi = ({ boardTitle, rightItem }: CommunityBoardTopNaviPropType) => {
   const router = useRouter();
 
   return (
@@ -29,11 +23,11 @@ const CommunityBoardTopNavi = ({
         <div css={{ display: 'flex', alignItems: 'center' }}>
           <IconArrowLeft
             iconCss={{ margin: '3px', width: '30px', height: '30px', cursor: 'pointer' }}
-            onClickBack={() => router.push(backLink)}
+            onClickBack={() => router.back()}
           />
           <h2>{boardTitle}</h2>
         </div>
-        {langSelector}
+        {rightItem}
       </div>
     </>
   );

--- a/src/components/organisms/CommunityBoardPagination.tsx
+++ b/src/components/organisms/CommunityBoardPagination.tsx
@@ -9,7 +9,7 @@ const CommunityBoardPagination = ({ totalCount }: { totalCount: number }) => {
   const { page } = router.query;
   const forcePage = Number(page) || 1;
   const handlePageChange = (event: { selected: number }) => {
-    router.push({
+    router.replace({
       pathname: router.pathname,
       query: {
         ...router.query,

--- a/src/components/organisms/community/CommunityBoardNoPost.tsx
+++ b/src/components/organisms/community/CommunityBoardNoPost.tsx
@@ -1,0 +1,34 @@
+import GradientButton from '@/components/atoms/GradientButton';
+
+type OwnPropType = {
+  texts?: string[];
+  buttonText: string;
+  onClickWrite: () => void;
+};
+
+const CommunityBoardNoPost = ({ texts, buttonText, onClickWrite }: OwnPropType) => {
+  return (
+    <div
+      css={{
+        width: '100%',
+        height: '50vh',
+        padding: '0px 15px',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        lineHeight: '1.5',
+        color: '#999',
+        fontSize: '20px',
+        textAlign: 'center',
+      }}
+    >
+      {texts?.map((text, idx) => {
+        return <p key={idx}>{text}</p>;
+      })}
+      <GradientButton text={buttonText} onClick={onClickWrite} />
+    </div>
+  );
+};
+
+export default CommunityBoardNoPost;

--- a/src/components/organisms/community/CommunityNoRecentBoard.tsx
+++ b/src/components/organisms/community/CommunityNoRecentBoard.tsx
@@ -1,0 +1,41 @@
+import { Stack } from '@/components/atoms';
+import GradientButton from '@/components/atoms/GradientButton';
+
+type CommunityNoRecentBoardType = {
+  title: string;
+  texts: string[];
+  buttonText: string;
+  onClickSearch: () => void;
+};
+
+const CommunityNoRecentBoard = ({
+  title,
+  texts,
+  buttonText,
+  onClickSearch,
+}: CommunityNoRecentBoardType) => {
+  return (
+    <section css={{ marginBottom: '30px' }}>
+      <h4 css={{ margin: '15px 5px' }}>{title}</h4>
+      <Stack
+        align="center"
+        justify="center"
+        css={{
+          padding: '40px 15px',
+          lineHeight: '1.8',
+          fontWeight: '600',
+          fontSize: '18px',
+          color: '#666',
+          textAlign: 'center',
+        }}
+      >
+        {texts.map((text, idx) => {
+          return <p key={idx}>{text}</p>;
+        })}
+        <GradientButton text={buttonText} onClick={onClickSearch} />
+      </Stack>
+    </section>
+  );
+};
+
+export default CommunityNoRecentBoard;

--- a/src/components/templates/CommunityBoardTemplate.tsx
+++ b/src/components/templates/CommunityBoardTemplate.tsx
@@ -15,18 +15,19 @@ import IconPopularBlack from '../atoms/IconPopularBlack';
 import IconMyPost from '../atoms/IconMyPost';
 import IconPopular from '../atoms/IconPopular';
 import CommunityLanguageModal from '../modals/CommunityLanguageModal';
+import CommunityBoardNoPost from '../organisms/community/CommunityBoardNoPost';
 
 // TODO 1. 각 게시글 실제 link 연결 (경은님과 함께 해야함) (하단 탭바의 글쓰기 링크도 연결해야함)
 
 export type CommunityBoardPropType = {
-  isMyPost?: boolean;
+  isMyPostPage?: boolean;
   communityBoardData: CommunityBoardResponseType;
   communityBoardTopics: CommunityBoardTopicResponseType;
   texts: CommunityBoardTextType;
 };
 
 const CommunityBoardTemplate = ({
-  isMyPost,
+  isMyPostPage,
   communityBoardData,
   communityBoardTopics,
   texts,
@@ -50,7 +51,8 @@ const CommunityBoardTemplate = ({
   const postList = communityBoardData.RESULTS.DATAS.POST_LIST;
   const boardInfo = communityBoardData.RESULTS.DATAS.BOARD_INFO;
 
-  const backLink = isMyPost ? `/community/board/${boardInfo.BOARD_IDX}` : '/community';
+  const isPostExist = postList.length !== 0;
+  const backLink = isMyPostPage ? `/community/board/${boardInfo.BOARD_IDX}` : '/community';
 
   const onClickWrite = () => router.push('/');
   const onClickPopular = () => {
@@ -78,12 +80,12 @@ const CommunityBoardTemplate = ({
     >
       <CommunityBoardTopNavi
         backLink={backLink}
-        boardTitle={!isMyPost ? boardInfo.BOARD_TITLE : texts.bottomTabBar.myPost}
-        withLang={!isMyPost}
+        boardTitle={!isMyPostPage ? boardInfo.BOARD_TITLE : texts.bottomTabBar.myPost}
+        withLang={!isMyPostPage}
         language={texts.boardLang[boardLang]}
         setLangModal={setLangModal}
       />
-      {!isMyPost && (
+      {!isMyPostPage && (
         <TopicTabBar
           stringTopicAll={texts.all}
           topicList={topicList}
@@ -91,23 +93,33 @@ const CommunityBoardTemplate = ({
           setTopicIndex={setTopicIndex}
         />
       )}
-      <ul>
-        {postList.map((post, idx) => {
-          return <CommunityBoardArticle postItem={post} link="/" key={idx} texts={texts} />;
-        })}
-      </ul>
+      {isPostExist ? (
+        <ul>
+          {postList.map((post, idx) => {
+            return <CommunityBoardArticle postItem={post} link="/" key={idx} texts={texts} />;
+          })}
+        </ul>
+      ) : (
+        <CommunityBoardNoPost
+          onClickWrite={onClickWrite}
+          buttonText={texts.buttonWrite}
+          texts={isMyPostPage ? texts.noMyPostTexts : texts.noPostTexts}
+        />
+      )}
       <CommunityBoardPagination totalCount={parseInt(boardInfo.POST_CNT) || 200} />
-      <BottomTabBar
-        items={[
-          { icon: <IconWrite />, title: texts.bottomTabBar.write, onClick: onClickWrite },
-          {
-            icon: viewType === 'best_post' ? <IconPopular /> : <IconPopularBlack />,
-            title: texts.bottomTabBar.popular,
-            onClick: onClickPopular,
-          },
-          { icon: <IconMyPost />, title: texts.bottomTabBar.myPost, onClick: onClickMyPost },
-        ]}
-      />
+      {!isMyPostPage && (
+        <BottomTabBar
+          items={[
+            { icon: <IconWrite />, title: texts.bottomTabBar.write, onClick: onClickWrite },
+            {
+              icon: viewType === 'best_post' ? <IconPopular /> : <IconPopularBlack />,
+              title: texts.bottomTabBar.popular,
+              onClick: onClickPopular,
+            },
+            { icon: <IconMyPost />, title: texts.bottomTabBar.myPost, onClick: onClickMyPost },
+          ]}
+        />
+      )}
       <CommunityLanguageModal
         texts={texts.boardLang}
         opened={langModal}

--- a/src/components/templates/CommunityBoardTemplate.tsx
+++ b/src/components/templates/CommunityBoardTemplate.tsx
@@ -40,12 +40,6 @@ const CommunityBoardTemplate = ({
   );
   const [langModal, setLangModal] = useState(false);
 
-  useEffect(() => {
-    setTopicIndex(parseInt(router.query.topic as string) || 0);
-    setViewType((router.query.view as string) || 'all');
-    setBoardLang((router.query.boardLang as BackLangType) || 'ALL');
-  }, [router.query]);
-
   const topicList = communityBoardTopics.RESULTS.DATAS.TOPIC_LIST;
   const postList = communityBoardData.RESULTS.DATAS.POST_LIST;
   const boardInfo = communityBoardData.RESULTS.DATAS.BOARD_INFO;

--- a/src/components/templates/CommunityBoardTemplate.tsx
+++ b/src/components/templates/CommunityBoardTemplate.tsx
@@ -16,18 +16,17 @@ import IconMyPost from '../atoms/IconMyPost';
 import IconPopular from '../atoms/IconPopular';
 import CommunityLanguageModal from '../modals/CommunityLanguageModal';
 import CommunityBoardNoPost from '../organisms/community/CommunityBoardNoPost';
+import CommunityBoardLangSelector from '../molecules/CommunityBoardLangSelector';
 
 // TODO 1. 각 게시글 실제 link 연결 (경은님과 함께 해야함) (하단 탭바의 글쓰기 링크도 연결해야함)
 
 export type CommunityBoardPropType = {
-  isMyPostPage?: boolean;
   communityBoardData: CommunityBoardResponseType;
   communityBoardTopics: CommunityBoardTopicResponseType;
   texts: CommunityBoardTextType;
 };
 
 const CommunityBoardTemplate = ({
-  isMyPostPage,
   communityBoardData,
   communityBoardTopics,
   texts,
@@ -52,7 +51,6 @@ const CommunityBoardTemplate = ({
   const boardInfo = communityBoardData.RESULTS.DATAS.BOARD_INFO;
 
   const isPostExist = postList.length !== 0;
-  const showTabBar = !isMyPostPage;
 
   const onClickWrite = () => router.push('/');
   const onClickPopular = () => {
@@ -79,20 +77,21 @@ const CommunityBoardTemplate = ({
       }}
     >
       <CommunityBoardTopNavi
-        backLink={!isMyPostPage ? '/community' : `/community/board/${boardInfo.BOARD_IDX}`}
-        boardTitle={!isMyPostPage ? boardInfo.BOARD_TITLE : texts.bottomTabBar.myPost}
-        withLang={!isMyPostPage}
-        language={texts.boardLang[boardLang]}
-        setLangModal={setLangModal}
+        backLink="/community"
+        boardTitle={boardInfo.BOARD_TITLE}
+        langSelector={
+          <CommunityBoardLangSelector
+            language={texts.boardLang[boardLang]}
+            onClick={() => setLangModal(true)}
+          />
+        }
       />
-      {showTabBar && (
-        <TopicTabBar
-          stringTopicAll={texts.all}
-          topicList={topicList}
-          topicIndex={topicIndex}
-          setTopicIndex={setTopicIndex}
-        />
-      )}
+      <TopicTabBar
+        stringTopicAll={texts.all}
+        topicList={topicList}
+        topicIndex={topicIndex}
+        setTopicIndex={setTopicIndex}
+      />
       {isPostExist ? (
         <ul>
           {postList.map((post, idx) => {
@@ -103,23 +102,21 @@ const CommunityBoardTemplate = ({
         <CommunityBoardNoPost
           onClickWrite={onClickWrite}
           buttonText={texts.buttonWrite}
-          texts={isMyPostPage ? texts.noMyPostTexts : texts.noPostTexts}
+          texts={texts.noPostTexts}
         />
       )}
       <CommunityBoardPagination totalCount={parseInt(boardInfo.POST_CNT) || 200} />
-      {showTabBar && (
-        <BottomTabBar
-          items={[
-            { icon: <IconWrite />, title: texts.bottomTabBar.write, onClick: onClickWrite },
-            {
-              icon: viewType === 'best_post' ? <IconPopular /> : <IconPopularBlack />,
-              title: texts.bottomTabBar.popular,
-              onClick: onClickPopular,
-            },
-            { icon: <IconMyPost />, title: texts.bottomTabBar.myPost, onClick: onClickMyPost },
-          ]}
-        />
-      )}
+      <BottomTabBar
+        items={[
+          { icon: <IconWrite />, title: texts.bottomTabBar.write, onClick: onClickWrite },
+          {
+            icon: viewType === 'best_post' ? <IconPopular /> : <IconPopularBlack />,
+            title: texts.bottomTabBar.popular,
+            onClick: onClickPopular,
+          },
+          { icon: <IconMyPost />, title: texts.bottomTabBar.myPost, onClick: onClickMyPost },
+        ]}
+      />
       <CommunityLanguageModal
         texts={texts.boardLang}
         opened={langModal}

--- a/src/components/templates/CommunityBoardTemplate.tsx
+++ b/src/components/templates/CommunityBoardTemplate.tsx
@@ -56,14 +56,14 @@ const CommunityBoardTemplate = ({
   const onClickPopular = () => {
     if (viewType !== 'best_post') {
       setViewType('best_post');
-      router.push({
+      router.replace({
         pathname: router.pathname,
         query: { ...router.query, view: 'best_post', page: 1 },
       });
       return;
     }
     setViewType('all');
-    router.push({ pathname: router.pathname, query: { ...router.query, view: 'all', page: 1 } });
+    router.replace({ pathname: router.pathname, query: { ...router.query, view: 'all', page: 1 } });
   };
   const onClickMyPost = () => router.push(`/community/board/${boardInfo.BOARD_IDX}/mypost`);
 
@@ -77,9 +77,8 @@ const CommunityBoardTemplate = ({
       }}
     >
       <CommunityBoardTopNavi
-        backLink="/community"
         boardTitle={boardInfo.BOARD_TITLE}
-        langSelector={
+        rightItem={
           <CommunityBoardLangSelector
             language={texts.boardLang[boardLang]}
             onClick={() => setLangModal(true)}
@@ -146,7 +145,7 @@ const TopicTabBar = ({
   const router = useRouter();
   const handleClick = (topicIndex: number) => {
     setTopicIndex(topicIndex);
-    router.push({ pathname: router.pathname, query: { ...router.query, topic: topicIndex } });
+    router.replace({ pathname: router.pathname, query: { ...router.query, topic: topicIndex } });
   };
   return (
     <ul

--- a/src/components/templates/CommunityBoardTemplate.tsx
+++ b/src/components/templates/CommunityBoardTemplate.tsx
@@ -52,7 +52,7 @@ const CommunityBoardTemplate = ({
   const boardInfo = communityBoardData.RESULTS.DATAS.BOARD_INFO;
 
   const isPostExist = postList.length !== 0;
-  const backLink = isMyPostPage ? `/community/board/${boardInfo.BOARD_IDX}` : '/community';
+  const showTabBar = !isMyPostPage;
 
   const onClickWrite = () => router.push('/');
   const onClickPopular = () => {
@@ -79,13 +79,13 @@ const CommunityBoardTemplate = ({
       }}
     >
       <CommunityBoardTopNavi
-        backLink={backLink}
+        backLink={!isMyPostPage ? '/community' : `/community/board/${boardInfo.BOARD_IDX}`}
         boardTitle={!isMyPostPage ? boardInfo.BOARD_TITLE : texts.bottomTabBar.myPost}
         withLang={!isMyPostPage}
         language={texts.boardLang[boardLang]}
         setLangModal={setLangModal}
       />
-      {!isMyPostPage && (
+      {showTabBar && (
         <TopicTabBar
           stringTopicAll={texts.all}
           topicList={topicList}
@@ -107,7 +107,7 @@ const CommunityBoardTemplate = ({
         />
       )}
       <CommunityBoardPagination totalCount={parseInt(boardInfo.POST_CNT) || 200} />
-      {!isMyPostPage && (
+      {showTabBar && (
         <BottomTabBar
           items={[
             { icon: <IconWrite />, title: texts.bottomTabBar.write, onClick: onClickWrite },

--- a/src/components/templates/CommunityMyPostTemplate.tsx
+++ b/src/components/templates/CommunityMyPostTemplate.tsx
@@ -32,10 +32,7 @@ const CommunityMyPostTemplate = ({ communityBoardData, texts }: CommunityMyPostP
         position: 'relative',
       }}
     >
-      <CommunityBoardTopNavi
-        backLink={`/community/board/${boardInfo.BOARD_IDX}`}
-        boardTitle={texts.bottomTabBar.myPost}
-      />
+      <CommunityBoardTopNavi boardTitle={texts.bottomTabBar.myPost} />
       {isPostExist ? (
         <ul>
           {postList.map((post, idx) => {

--- a/src/components/templates/CommunityMyPostTemplate.tsx
+++ b/src/components/templates/CommunityMyPostTemplate.tsx
@@ -1,0 +1,57 @@
+import type { CommunityBoardResponseType } from '@/types/community';
+import type { CommunityBoardTextType } from '@/types/textTypes';
+import { useRouter } from 'next/router';
+import CommunityBoardTopNavi from '../molecules/CommunityBoardTopNavi';
+import CommunityBoardArticle from '../molecules/CommunityBoardArticle';
+import CommunityBoardPagination from '../organisms/CommunityBoardPagination';
+import CommunityBoardNoPost from '../organisms/community/CommunityBoardNoPost';
+
+// TODO 1. 각 게시글 실제 link 연결 (경은님과 함께 해야함) (하단 탭바의 글쓰기 링크도 연결해야함)
+
+export type CommunityMyPostPropType = {
+  communityBoardData: CommunityBoardResponseType;
+  texts: CommunityBoardTextType;
+};
+
+const CommunityMyPostTemplate = ({ communityBoardData, texts }: CommunityMyPostPropType) => {
+  const router = useRouter();
+
+  const postList = communityBoardData.RESULTS.DATAS.POST_LIST;
+  const boardInfo = communityBoardData.RESULTS.DATAS.BOARD_INFO;
+
+  const isPostExist = postList.length !== 0;
+
+  const onClickWrite = () => router.push('/');
+
+  return (
+    <div
+      css={{
+        width: '100%',
+        maxWidth: '768px',
+        margin: '0px auto',
+        position: 'relative',
+      }}
+    >
+      <CommunityBoardTopNavi
+        backLink={`/community/board/${boardInfo.BOARD_IDX}`}
+        boardTitle={texts.bottomTabBar.myPost}
+      />
+      {isPostExist ? (
+        <ul>
+          {postList.map((post, idx) => {
+            return <CommunityBoardArticle postItem={post} link="/" key={idx} texts={texts} />;
+          })}
+        </ul>
+      ) : (
+        <CommunityBoardNoPost
+          onClickWrite={onClickWrite}
+          buttonText={texts.buttonWrite}
+          texts={texts.noMyPostTexts}
+        />
+      )}
+      <CommunityBoardPagination totalCount={parseInt(boardInfo.POST_CNT) || 1} />
+    </div>
+  );
+};
+
+export default CommunityMyPostTemplate;

--- a/src/components/templates/CommunityPageTemplate.tsx
+++ b/src/components/templates/CommunityPageTemplate.tsx
@@ -1,16 +1,16 @@
-import { CommunityMainText_KR } from '@/texts/ko';
-import {
+import type {
   CommunityBoardCategoryResponseType,
   CommunityBoardResultResponseType,
   CommunityHomeResponseType,
 } from '@/types/community';
+import type { CommunityPageTextType } from '@/types/textTypes';
 import { Dispatch, SetStateAction, useState } from 'react';
-import { CommunityPageTextType } from '@/types/textTypes';
 import CommunityBoardWrapper from '../organisms/community/CommunityBoardWrapper';
 import CommunityBoardFilterTab from '@/components/organisms/community/CommunityBoardFilterTab';
 import CommunitySearchBoardWrapper from '@/components/organisms/community/CommunitySearchBoardWrapper';
 import CommunityBoardSearchInputWrapper from '@/components/organisms/community/CommunityBoardSearchInputWrapper';
 import CommunitySearchBoardPagination from '@/components/organisms/community/CommunitySearchBoardPagination';
+import CommunityNoRecentBoard from '../organisms/community/CommunityNoRecentBoard';
 
 export type CommunityPropTypes = {
   communityHomeData: CommunityHomeResponseType;
@@ -25,15 +25,17 @@ const CommunityPageTemplate = ({
   communityHomeData,
   boardCategoryData,
   boardResultData,
-  texts
+  texts,
 }: CommunityPropTypes) => {
-  const [tabBar, setTabBar] = useState<TabBarType>('search');
+  const [tabBar, setTabBar] = useState<TabBarType>('home');
   const searchTabState = useState<string>('전체');
   const [activeTabState] = searchTabState;
 
   const recentlyList = communityHomeData.RESULTS.DATAS.RECENTLY_LIST;
   const recommendList = communityHomeData.RESULTS.DATAS.RECOMMEND_LIST;
   const boardResultList = boardResultData.RESULTS.DATAS.BOARD_LIST;
+
+  const isRecentlyListExist = recentlyList.length !== 0;
 
   /**
    * searchCategoryTab : IDX - NAME
@@ -59,7 +61,16 @@ const CommunityPageTemplate = ({
       />
       {tabBar === 'home' ? (
         <>
-          <CommunityBoardWrapper title={texts.recentlyBoards} boardList={recentlyList} />
+          {isRecentlyListExist ? (
+            <CommunityBoardWrapper title={texts.recentlyBoards} boardList={recentlyList} />
+          ) : (
+            <CommunityNoRecentBoard
+              title={texts.recentlyBoards}
+              texts={texts.noRecentBoardTexts}
+              buttonText={texts.buttonSearch}
+              onClickSearch={() => setTabBar('search')}
+            />
+          )}
           <CommunityBoardWrapper title={texts.recommendedBoards} boardList={recommendList} />
         </>
       ) : (

--- a/src/pages/api/community/withoutUserId/board.ts
+++ b/src/pages/api/community/withoutUserId/board.ts
@@ -1,0 +1,26 @@
+import { NextApiHandler } from 'next';
+import axios, { AxiosResponse } from 'axios';
+import type { CommunityBoardResponseType } from '@/types/community';
+
+const handler: NextApiHandler = async (req, res) => {
+  const { boardIndex, page, lang, boardLang, view_type, topic } = req.query;
+  const origin = process.env.NEXT_PUBLIC_CLIENT_URL || 'https://dev.fanplus.co.kr';
+
+  try {
+    const response: AxiosResponse<CommunityBoardResponseType> = await axios.get(
+      `https://napi.appphotocard.com/voteWeb/boards/${boardIndex}?` +
+        `&page=${page}&per_page=20&lang=${lang}&filter_lang=${boardLang}&view_type=${view_type}&topic_ids[]=${topic}`,
+      {
+        headers: {
+          Origin: origin,
+          'Cache-Control': 'no-cache',
+        },
+      }
+    );
+    res.status(200).json(response.data);
+  } catch (error) {
+    res.status(500).json('Failed to load Community-Board data');
+  }
+};
+
+export default handler;

--- a/src/pages/api/community/withoutUserId/board.ts
+++ b/src/pages/api/community/withoutUserId/board.ts
@@ -1,26 +1,26 @@
-import { NextApiHandler } from 'next';
-import axios, { AxiosResponse } from 'axios';
-import type { CommunityBoardResponseType } from '@/types/community';
+// import { NextApiHandler } from 'next';
+// import axios, { AxiosResponse } from 'axios';
+// import type { CommunityBoardResponseType } from '@/types/community';
 
-const handler: NextApiHandler = async (req, res) => {
-  const { boardIndex, page, lang, boardLang, view_type, topic } = req.query;
-  const origin = process.env.NEXT_PUBLIC_CLIENT_URL || 'https://dev.fanplus.co.kr';
+// const handler: NextApiHandler = async (req, res) => {
+//   const { boardIndex, page, lang, boardLang, view_type, topic } = req.query;
+//   const origin = process.env.NEXT_PUBLIC_CLIENT_URL || 'https://dev.fanplus.co.kr';
 
-  try {
-    const response: AxiosResponse<CommunityBoardResponseType> = await axios.get(
-      `https://napi.appphotocard.com/voteWeb/boards/${boardIndex}?` +
-        `&page=${page}&per_page=20&lang=${lang}&filter_lang=${boardLang}&view_type=${view_type}&topic_ids[]=${topic}`,
-      {
-        headers: {
-          Origin: origin,
-          'Cache-Control': 'no-cache',
-        },
-      }
-    );
-    res.status(200).json(response.data);
-  } catch (error) {
-    res.status(500).json('Failed to load Community-Board data');
-  }
-};
+//   try {
+//     const response: AxiosResponse<CommunityBoardResponseType> = await axios.get(
+//       `https://napi.appphotocard.com/voteWeb/boards/${boardIndex}?` +
+//         `&page=${page}&per_page=20&lang=${lang}&filter_lang=${boardLang}&view_type=${view_type}&topic_ids[]=${topic}`,
+//       {
+//         headers: {
+//           Origin: origin,
+//           'Cache-Control': 'no-cache',
+//         },
+//       }
+//     );
+//     res.status(200).json(response.data);
+//   } catch (error) {
+//     res.status(500).json('Failed to load Community-Board data');
+//   }
+// };
 
-export default handler;
+// export default handler;

--- a/src/pages/api/community/withoutUserId/home.ts
+++ b/src/pages/api/community/withoutUserId/home.ts
@@ -1,25 +1,25 @@
-import { NextApiHandler } from 'next';
-import axios, { AxiosResponse } from 'axios';
-import type { CommunityHomeResponseTypeWithoutUserId } from '@/types/community';
+// import { NextApiHandler } from 'next';
+// import axios, { AxiosResponse } from 'axios';
+// import type { CommunityHomeResponseTypeWithoutUserId } from '@/types/community';
 
-const handler: NextApiHandler = async (req, res) => {
-  const lang = req.query.lang;
-  const origin = process.env.NEXT_PUBLIC_CLIENT_URL || 'https://dev.fanplus.co.kr';
+// const handler: NextApiHandler = async (req, res) => {
+//   const lang = req.query.lang;
+//   const origin = process.env.NEXT_PUBLIC_CLIENT_URL || 'https://dev.fanplus.co.kr';
 
-  try {
-    const response: AxiosResponse<CommunityHomeResponseTypeWithoutUserId> = await axios.get(
-      `https://napi.appphotocard.com/voteWeb/boards/0?lang=${lang}`,
-      {
-        headers: {
-          Origin: origin,
-          'Cache-Control': 'no-cache',
-        },
-      }
-    );
-    res.status(200).json(response.data);
-  } catch (error) {
-    res.status(500).json('failed to load data');
-  }
-};
+//   try {
+//     const response: AxiosResponse<CommunityHomeResponseTypeWithoutUserId> = await axios.get(
+//       `https://napi.appphotocard.com/voteWeb/boards/0?lang=${lang}`,
+//       {
+//         headers: {
+//           Origin: origin,
+//           'Cache-Control': 'no-cache',
+//         },
+//       }
+//     );
+//     res.status(200).json(response.data);
+//   } catch (error) {
+//     res.status(500).json('failed to load data');
+//   }
+// };
 
-export default handler;
+// export default handler;

--- a/src/pages/api/community/withoutUserId/home.ts
+++ b/src/pages/api/community/withoutUserId/home.ts
@@ -1,0 +1,25 @@
+import { NextApiHandler } from 'next';
+import axios, { AxiosResponse } from 'axios';
+import type { CommunityHomeResponseTypeWithoutUserId } from '@/types/community';
+
+const handler: NextApiHandler = async (req, res) => {
+  const lang = req.query.lang;
+  const origin = process.env.NEXT_PUBLIC_CLIENT_URL || 'https://dev.fanplus.co.kr';
+
+  try {
+    const response: AxiosResponse<CommunityHomeResponseTypeWithoutUserId> = await axios.get(
+      `https://napi.appphotocard.com/voteWeb/boards/0?lang=${lang}`,
+      {
+        headers: {
+          Origin: origin,
+          'Cache-Control': 'no-cache',
+        },
+      }
+    );
+    res.status(200).json(response.data);
+  } catch (error) {
+    res.status(500).json('failed to load data');
+  }
+};
+
+export default handler;

--- a/src/pages/en/community/board/[boardIndex]/mypost.tsx
+++ b/src/pages/en/community/board/[boardIndex]/mypost.tsx
@@ -1,30 +1,26 @@
 import { getCommunityBoardData, getCommunityBoardTopics } from '@/api/Community';
-import CommunityBoardTemplate, {
-  CommunityBoardPropType,
-} from '@/components/templates/CommunityBoardTemplate';
-import { translateFrontLangToBackLang } from '@/hooks/useLanguage';
-import { LangCookie } from '@/utils/setLangCookie';
 import { GetServerSideProps } from 'next';
 import { CommunityBoardText_ENG, FooterText_ENG, NavBarText_ENG } from '@/texts/en';
 import nookies from 'nookies';
 import Layout from '@/components/organisms/Layout';
+import CommunityMyPostTemplate, {
+  CommunityMyPostPropType,
+} from '@/components/templates/CommunityMyPostTemplate';
 
-const MyPost = ({ communityBoardData, communityBoardTopics }: CommunityBoardPropType) => {
+const MyPost = ({ communityBoardData }: CommunityMyPostPropType) => {
   return (
     <Layout navBarTexts={NavBarText_ENG} footerTexts={FooterText_ENG}>
-      <CommunityBoardTemplate
-        isMyPostPage
+      <CommunityMyPostTemplate
         communityBoardData={communityBoardData}
-        communityBoardTopics={communityBoardTopics}
         texts={CommunityBoardText_ENG}
       />
     </Layout>
   );
 };
 
-export const getServerSideProps: GetServerSideProps<Omit<CommunityBoardPropType, 'texts'>> = async (
-  context
-) => {
+export const getServerSideProps: GetServerSideProps<
+  Omit<CommunityMyPostPropType, 'texts'>
+> = async (context) => {
   // const cookies = nookies.get(context);
   // const userId = cookies['user_id'];
   const userId = '1a11a56286d1c02c5eb4f38b6d6fa0f5d2db490e0783d70f1b0db7746c96d1cc';
@@ -32,8 +28,8 @@ export const getServerSideProps: GetServerSideProps<Omit<CommunityBoardPropType,
   const boardIndex = parseInt(context.query.boardIndex as string);
   const page = parseInt(context.query.page as string) - 1 || 0;
   const lang = 'en';
-  const boardLang = translateFrontLangToBackLang(context.query.boardLang as LangCookie) || 'ALL';
-  const topic = parseInt(context.query.topic as string) || '';
+  const boardLang = 'ALL';
+  const topic = '';
   const view_type = 'my_post';
 
   if (!boardIndex) return { notFound: true };

--- a/src/pages/en/community/board/[boardIndex]/mypost.tsx
+++ b/src/pages/en/community/board/[boardIndex]/mypost.tsx
@@ -13,7 +13,7 @@ const MyPost = ({ communityBoardData, communityBoardTopics }: CommunityBoardProp
   return (
     <Layout navBarTexts={NavBarText_ENG} footerTexts={FooterText_ENG}>
       <CommunityBoardTemplate
-        isMyPost
+        isMyPostPage
         communityBoardData={communityBoardData}
         communityBoardTopics={communityBoardTopics}
         texts={CommunityBoardText_ENG}

--- a/src/pages/es/community/board/[boardIndex]/mypost.tsx
+++ b/src/pages/es/community/board/[boardIndex]/mypost.tsx
@@ -1,30 +1,26 @@
 import { getCommunityBoardData, getCommunityBoardTopics } from '@/api/Community';
-import CommunityBoardTemplate, {
-  CommunityBoardPropType,
-} from '@/components/templates/CommunityBoardTemplate';
-import { translateFrontLangToBackLang } from '@/hooks/useLanguage';
-import { LangCookie } from '@/utils/setLangCookie';
 import { GetServerSideProps } from 'next';
 import { CommunityBoardText_ESP, FooterText_ESP, NavBarText_ESP } from '@/texts/es';
 import nookies from 'nookies';
 import Layout from '@/components/organisms/Layout';
+import CommunityMyPostTemplate, {
+  CommunityMyPostPropType,
+} from '@/components/templates/CommunityMyPostTemplate';
 
-const MyPost = ({ communityBoardData, communityBoardTopics }: CommunityBoardPropType) => {
+const MyPost = ({ communityBoardData }: CommunityMyPostPropType) => {
   return (
     <Layout navBarTexts={NavBarText_ESP} footerTexts={FooterText_ESP}>
-      <CommunityBoardTemplate
-        isMyPostPage
+      <CommunityMyPostTemplate
         communityBoardData={communityBoardData}
-        communityBoardTopics={communityBoardTopics}
         texts={CommunityBoardText_ESP}
       />
     </Layout>
   );
 };
 
-export const getServerSideProps: GetServerSideProps<Omit<CommunityBoardPropType, 'texts'>> = async (
-  context
-) => {
+export const getServerSideProps: GetServerSideProps<
+  Omit<CommunityMyPostPropType, 'texts'>
+> = async (context) => {
   // const cookies = nookies.get(context);
   // const userId = cookies['user_id'];
   const userId = '1a11a56286d1c02c5eb4f38b6d6fa0f5d2db490e0783d70f1b0db7746c96d1cc';
@@ -32,8 +28,8 @@ export const getServerSideProps: GetServerSideProps<Omit<CommunityBoardPropType,
   const boardIndex = parseInt(context.query.boardIndex as string);
   const page = parseInt(context.query.page as string) - 1 || 0;
   const lang = 'es';
-  const boardLang = translateFrontLangToBackLang(context.query.boardLang as LangCookie) || 'ALL';
-  const topic = parseInt(context.query.topic as string) || '';
+  const boardLang = 'ALL';
+  const topic = '';
   const view_type = 'my_post';
 
   if (!boardIndex) return { notFound: true };

--- a/src/pages/es/community/board/[boardIndex]/mypost.tsx
+++ b/src/pages/es/community/board/[boardIndex]/mypost.tsx
@@ -13,7 +13,7 @@ const MyPost = ({ communityBoardData, communityBoardTopics }: CommunityBoardProp
   return (
     <Layout navBarTexts={NavBarText_ESP} footerTexts={FooterText_ESP}>
       <CommunityBoardTemplate
-        isMyPost
+        isMyPostPage
         communityBoardData={communityBoardData}
         communityBoardTopics={communityBoardTopics}
         texts={CommunityBoardText_ESP}

--- a/src/pages/in/community/board/[boardIndex]/mypost.tsx
+++ b/src/pages/in/community/board/[boardIndex]/mypost.tsx
@@ -1,30 +1,26 @@
 import { getCommunityBoardData, getCommunityBoardTopics } from '@/api/Community';
-import CommunityBoardTemplate, {
-  CommunityBoardPropType,
-} from '@/components/templates/CommunityBoardTemplate';
-import { translateFrontLangToBackLang } from '@/hooks/useLanguage';
-import { LangCookie } from '@/utils/setLangCookie';
 import { GetServerSideProps } from 'next';
 import { CommunityBoardText_IND, FooterText_IND, NavBarText_IND } from '@/texts/in';
 import nookies from 'nookies';
 import Layout from '@/components/organisms/Layout';
+import CommunityMyPostTemplate, {
+  CommunityMyPostPropType,
+} from '@/components/templates/CommunityMyPostTemplate';
 
-const MyPost = ({ communityBoardData, communityBoardTopics }: CommunityBoardPropType) => {
+const MyPost = ({ communityBoardData }: CommunityMyPostPropType) => {
   return (
     <Layout navBarTexts={NavBarText_IND} footerTexts={FooterText_IND}>
-      <CommunityBoardTemplate
-        isMyPostPage
+      <CommunityMyPostTemplate
         communityBoardData={communityBoardData}
-        communityBoardTopics={communityBoardTopics}
         texts={CommunityBoardText_IND}
       />
     </Layout>
   );
 };
 
-export const getServerSideProps: GetServerSideProps<Omit<CommunityBoardPropType, 'texts'>> = async (
-  context
-) => {
+export const getServerSideProps: GetServerSideProps<
+  Omit<CommunityMyPostPropType, 'texts'>
+> = async (context) => {
   // const cookies = nookies.get(context);
   // const userId = cookies['user_id'];
   const userId = '1a11a56286d1c02c5eb4f38b6d6fa0f5d2db490e0783d70f1b0db7746c96d1cc';
@@ -32,8 +28,8 @@ export const getServerSideProps: GetServerSideProps<Omit<CommunityBoardPropType,
   const boardIndex = parseInt(context.query.boardIndex as string);
   const page = parseInt(context.query.page as string) - 1 || 0;
   const lang = 'id';
-  const boardLang = translateFrontLangToBackLang(context.query.boardLang as LangCookie) || 'ALL';
-  const topic = parseInt(context.query.topic as string) || '';
+  const boardLang = 'ALL';
+  const topic = '';
   const view_type = 'my_post';
 
   if (!boardIndex) return { notFound: true };

--- a/src/pages/in/community/board/[boardIndex]/mypost.tsx
+++ b/src/pages/in/community/board/[boardIndex]/mypost.tsx
@@ -13,7 +13,7 @@ const MyPost = ({ communityBoardData, communityBoardTopics }: CommunityBoardProp
   return (
     <Layout navBarTexts={NavBarText_IND} footerTexts={FooterText_IND}>
       <CommunityBoardTemplate
-        isMyPost
+        isMyPostPage
         communityBoardData={communityBoardData}
         communityBoardTopics={communityBoardTopics}
         texts={CommunityBoardText_IND}

--- a/src/pages/ja/community/board/[boardIndex]/mypost.tsx
+++ b/src/pages/ja/community/board/[boardIndex]/mypost.tsx
@@ -13,7 +13,7 @@ const MyPost = ({ communityBoardData, communityBoardTopics }: CommunityBoardProp
   return (
     <Layout navBarTexts={NavBarText_JAP} footerTexts={FooterText_JAP}>
       <CommunityBoardTemplate
-        isMyPost
+        isMyPostPage
         communityBoardData={communityBoardData}
         communityBoardTopics={communityBoardTopics}
         texts={CommunityBoardText_JAP}

--- a/src/pages/ja/community/board/[boardIndex]/mypost.tsx
+++ b/src/pages/ja/community/board/[boardIndex]/mypost.tsx
@@ -1,30 +1,26 @@
 import { getCommunityBoardData, getCommunityBoardTopics } from '@/api/Community';
-import CommunityBoardTemplate, {
-  CommunityBoardPropType,
-} from '@/components/templates/CommunityBoardTemplate';
-import { translateFrontLangToBackLang } from '@/hooks/useLanguage';
-import { LangCookie } from '@/utils/setLangCookie';
 import { GetServerSideProps } from 'next';
 import { CommunityBoardText_JAP, FooterText_JAP, NavBarText_JAP } from '@/texts/ja';
 import nookies from 'nookies';
 import Layout from '@/components/organisms/Layout';
+import CommunityMyPostTemplate, {
+  CommunityMyPostPropType,
+} from '@/components/templates/CommunityMyPostTemplate';
 
-const MyPost = ({ communityBoardData, communityBoardTopics }: CommunityBoardPropType) => {
+const MyPost = ({ communityBoardData }: CommunityMyPostPropType) => {
   return (
     <Layout navBarTexts={NavBarText_JAP} footerTexts={FooterText_JAP}>
-      <CommunityBoardTemplate
-        isMyPostPage
+      <CommunityMyPostTemplate
         communityBoardData={communityBoardData}
-        communityBoardTopics={communityBoardTopics}
         texts={CommunityBoardText_JAP}
       />
     </Layout>
   );
 };
 
-export const getServerSideProps: GetServerSideProps<Omit<CommunityBoardPropType, 'texts'>> = async (
-  context
-) => {
+export const getServerSideProps: GetServerSideProps<
+  Omit<CommunityMyPostPropType, 'texts'>
+> = async (context) => {
   // const cookies = nookies.get(context);
   // const userId = cookies['user_id'];
   const userId = '1a11a56286d1c02c5eb4f38b6d6fa0f5d2db490e0783d70f1b0db7746c96d1cc';
@@ -32,8 +28,8 @@ export const getServerSideProps: GetServerSideProps<Omit<CommunityBoardPropType,
   const boardIndex = parseInt(context.query.boardIndex as string);
   const page = parseInt(context.query.page as string) - 1 || 0;
   const lang = 'ja';
-  const boardLang = translateFrontLangToBackLang(context.query.boardLang as LangCookie) || 'ALL';
-  const topic = parseInt(context.query.topic as string) || '';
+  const boardLang = 'ALL';
+  const topic = '';
   const view_type = 'my_post';
 
   if (!boardIndex) return { notFound: true };

--- a/src/pages/ko/community/board/[boardIndex]/mypost.tsx
+++ b/src/pages/ko/community/board/[boardIndex]/mypost.tsx
@@ -13,7 +13,7 @@ const MyPost = ({ communityBoardData, communityBoardTopics }: CommunityBoardProp
   return (
     <Layout navBarTexts={NavBarText_KR} footerTexts={FooterText_KR}>
       <CommunityBoardTemplate
-        isMyPost
+        isMyPostPage
         communityBoardData={communityBoardData}
         communityBoardTopics={communityBoardTopics}
         texts={CommunityBoardText_KR}

--- a/src/pages/ko/community/board/[boardIndex]/mypost.tsx
+++ b/src/pages/ko/community/board/[boardIndex]/mypost.tsx
@@ -1,30 +1,26 @@
 import { getCommunityBoardData, getCommunityBoardTopics } from '@/api/Community';
-import CommunityBoardTemplate, {
-  CommunityBoardPropType,
-} from '@/components/templates/CommunityBoardTemplate';
-import { translateFrontLangToBackLang } from '@/hooks/useLanguage';
-import { LangCookie } from '@/utils/setLangCookie';
 import { GetServerSideProps } from 'next';
 import { CommunityBoardText_KR, FooterText_KR, NavBarText_KR } from '@/texts/ko';
 import nookies from 'nookies';
 import Layout from '@/components/organisms/Layout';
+import CommunityMyPostTemplate, {
+  CommunityMyPostPropType,
+} from '@/components/templates/CommunityMyPostTemplate';
 
-const MyPost = ({ communityBoardData, communityBoardTopics }: CommunityBoardPropType) => {
+const MyPost = ({ communityBoardData }: CommunityMyPostPropType) => {
   return (
     <Layout navBarTexts={NavBarText_KR} footerTexts={FooterText_KR}>
-      <CommunityBoardTemplate
-        isMyPostPage
+      <CommunityMyPostTemplate
         communityBoardData={communityBoardData}
-        communityBoardTopics={communityBoardTopics}
         texts={CommunityBoardText_KR}
       />
     </Layout>
   );
 };
 
-export const getServerSideProps: GetServerSideProps<Omit<CommunityBoardPropType, 'texts'>> = async (
-  context
-) => {
+export const getServerSideProps: GetServerSideProps<
+  Omit<CommunityMyPostPropType, 'texts'>
+> = async (context) => {
   // const cookies = nookies.get(context);
   // const userId = cookies['user_id'];
   const userId = '1a11a56286d1c02c5eb4f38b6d6fa0f5d2db490e0783d70f1b0db7746c96d1cc';
@@ -32,8 +28,8 @@ export const getServerSideProps: GetServerSideProps<Omit<CommunityBoardPropType,
   const boardIndex = parseInt(context.query.boardIndex as string);
   const page = parseInt(context.query.page as string) - 1 || 0;
   const lang = 'ko';
-  const boardLang = translateFrontLangToBackLang(context.query.boardLang as LangCookie) || 'ALL';
-  const topic = parseInt(context.query.topic as string) || '';
+  const boardLang = 'ALL';
+  const topic = '';
   const view_type = 'my_post';
 
   if (!boardIndex) return { notFound: true };

--- a/src/pages/vi/community/board/[boardIndex]/mypost.tsx
+++ b/src/pages/vi/community/board/[boardIndex]/mypost.tsx
@@ -13,7 +13,7 @@ const MyPost = ({ communityBoardData, communityBoardTopics }: CommunityBoardProp
   return (
     <Layout navBarTexts={NavBarText_VIE} footerTexts={FooterText_VIE}>
       <CommunityBoardTemplate
-        isMyPost
+        isMyPostPage
         communityBoardData={communityBoardData}
         communityBoardTopics={communityBoardTopics}
         texts={CommunityBoardText_VIE}

--- a/src/pages/vi/community/board/[boardIndex]/mypost.tsx
+++ b/src/pages/vi/community/board/[boardIndex]/mypost.tsx
@@ -1,30 +1,26 @@
 import { getCommunityBoardData, getCommunityBoardTopics } from '@/api/Community';
-import CommunityBoardTemplate, {
-  CommunityBoardPropType,
-} from '@/components/templates/CommunityBoardTemplate';
-import { translateFrontLangToBackLang } from '@/hooks/useLanguage';
-import { LangCookie } from '@/utils/setLangCookie';
 import { GetServerSideProps } from 'next';
 import { CommunityBoardText_VIE, FooterText_VIE, NavBarText_VIE } from '@/texts/vi';
 import nookies from 'nookies';
 import Layout from '@/components/organisms/Layout';
+import CommunityMyPostTemplate, {
+  CommunityMyPostPropType,
+} from '@/components/templates/CommunityMyPostTemplate';
 
-const MyPost = ({ communityBoardData, communityBoardTopics }: CommunityBoardPropType) => {
+const MyPost = ({ communityBoardData }: CommunityMyPostPropType) => {
   return (
     <Layout navBarTexts={NavBarText_VIE} footerTexts={FooterText_VIE}>
-      <CommunityBoardTemplate
-        isMyPostPage
+      <CommunityMyPostTemplate
         communityBoardData={communityBoardData}
-        communityBoardTopics={communityBoardTopics}
         texts={CommunityBoardText_VIE}
       />
     </Layout>
   );
 };
 
-export const getServerSideProps: GetServerSideProps<Omit<CommunityBoardPropType, 'texts'>> = async (
-  context
-) => {
+export const getServerSideProps: GetServerSideProps<
+  Omit<CommunityMyPostPropType, 'texts'>
+> = async (context) => {
   // const cookies = nookies.get(context);
   // const userId = cookies['user_id'];
   const userId = '1a11a56286d1c02c5eb4f38b6d6fa0f5d2db490e0783d70f1b0db7746c96d1cc';
@@ -32,8 +28,8 @@ export const getServerSideProps: GetServerSideProps<Omit<CommunityBoardPropType,
   const boardIndex = parseInt(context.query.boardIndex as string);
   const page = parseInt(context.query.page as string) - 1 || 0;
   const lang = 'vi';
-  const boardLang = translateFrontLangToBackLang(context.query.boardLang as LangCookie) || 'ALL';
-  const topic = parseInt(context.query.topic as string) || '';
+  const boardLang = 'ALL';
+  const topic = '';
   const view_type = 'my_post';
 
   if (!boardIndex) return { notFound: true };

--- a/src/pages/zh-CN/community/board/[boardIndex]/mypost.tsx
+++ b/src/pages/zh-CN/community/board/[boardIndex]/mypost.tsx
@@ -13,7 +13,7 @@ const MyPost = ({ communityBoardData, communityBoardTopics }: CommunityBoardProp
   return (
     <Layout navBarTexts={NavBarText_zh_CN} footerTexts={FooterText_zh_CN}>
       <CommunityBoardTemplate
-        isMyPost
+        isMyPostPage
         communityBoardData={communityBoardData}
         communityBoardTopics={communityBoardTopics}
         texts={CommunityBoardText_zh_CN}

--- a/src/pages/zh-CN/community/board/[boardIndex]/mypost.tsx
+++ b/src/pages/zh-CN/community/board/[boardIndex]/mypost.tsx
@@ -1,30 +1,26 @@
 import { getCommunityBoardData, getCommunityBoardTopics } from '@/api/Community';
-import CommunityBoardTemplate, {
-  CommunityBoardPropType,
-} from '@/components/templates/CommunityBoardTemplate';
-import { translateFrontLangToBackLang } from '@/hooks/useLanguage';
-import { LangCookie } from '@/utils/setLangCookie';
 import { GetServerSideProps } from 'next';
 import { CommunityBoardText_zh_CN, FooterText_zh_CN, NavBarText_zh_CN } from '@/texts/zh-CN';
 import nookies from 'nookies';
 import Layout from '@/components/organisms/Layout';
+import CommunityMyPostTemplate, {
+  CommunityMyPostPropType,
+} from '@/components/templates/CommunityMyPostTemplate';
 
-const MyPost = ({ communityBoardData, communityBoardTopics }: CommunityBoardPropType) => {
+const MyPost = ({ communityBoardData }: CommunityMyPostPropType) => {
   return (
     <Layout navBarTexts={NavBarText_zh_CN} footerTexts={FooterText_zh_CN}>
-      <CommunityBoardTemplate
-        isMyPostPage
+      <CommunityMyPostTemplate
         communityBoardData={communityBoardData}
-        communityBoardTopics={communityBoardTopics}
         texts={CommunityBoardText_zh_CN}
       />
     </Layout>
   );
 };
 
-export const getServerSideProps: GetServerSideProps<Omit<CommunityBoardPropType, 'texts'>> = async (
-  context
-) => {
+export const getServerSideProps: GetServerSideProps<
+  Omit<CommunityMyPostPropType, 'texts'>
+> = async (context) => {
   // const cookies = nookies.get(context);
   // const userId = cookies['user_id'];
   const userId = '1a11a56286d1c02c5eb4f38b6d6fa0f5d2db490e0783d70f1b0db7746c96d1cc';
@@ -32,8 +28,8 @@ export const getServerSideProps: GetServerSideProps<Omit<CommunityBoardPropType,
   const boardIndex = parseInt(context.query.boardIndex as string);
   const page = parseInt(context.query.page as string) - 1 || 0;
   const lang = 'zh';
-  const boardLang = translateFrontLangToBackLang(context.query.boardLang as LangCookie) || 'ALL';
-  const topic = parseInt(context.query.topic as string) || '';
+  const boardLang = 'ALL';
+  const topic = '';
   const view_type = 'my_post';
 
   if (!boardIndex) return { notFound: true };

--- a/src/pages/zh-TW/community/board/[boardIndex]/mypost.tsx
+++ b/src/pages/zh-TW/community/board/[boardIndex]/mypost.tsx
@@ -13,7 +13,7 @@ const MyPost = ({ communityBoardData, communityBoardTopics }: CommunityBoardProp
   return (
     <Layout navBarTexts={NavBarText_zh_TW} footerTexts={FooterText_zh_TW}>
       <CommunityBoardTemplate
-        isMyPost
+        isMyPostPage
         communityBoardData={communityBoardData}
         communityBoardTopics={communityBoardTopics}
         texts={CommunityBoardText_zh_TW}

--- a/src/pages/zh-TW/community/board/[boardIndex]/mypost.tsx
+++ b/src/pages/zh-TW/community/board/[boardIndex]/mypost.tsx
@@ -1,30 +1,26 @@
 import { getCommunityBoardData, getCommunityBoardTopics } from '@/api/Community';
-import CommunityBoardTemplate, {
-  CommunityBoardPropType,
-} from '@/components/templates/CommunityBoardTemplate';
-import { translateFrontLangToBackLang } from '@/hooks/useLanguage';
-import { LangCookie } from '@/utils/setLangCookie';
 import { GetServerSideProps } from 'next';
 import { CommunityBoardText_zh_TW, FooterText_zh_TW, NavBarText_zh_TW } from '@/texts/zh-TW';
 import nookies from 'nookies';
 import Layout from '@/components/organisms/Layout';
+import CommunityMyPostTemplate, {
+  CommunityMyPostPropType,
+} from '@/components/templates/CommunityMyPostTemplate';
 
-const MyPost = ({ communityBoardData, communityBoardTopics }: CommunityBoardPropType) => {
+const MyPost = ({ communityBoardData }: CommunityMyPostPropType) => {
   return (
     <Layout navBarTexts={NavBarText_zh_TW} footerTexts={FooterText_zh_TW}>
-      <CommunityBoardTemplate
-        isMyPostPage
+      <CommunityMyPostTemplate
         communityBoardData={communityBoardData}
-        communityBoardTopics={communityBoardTopics}
         texts={CommunityBoardText_zh_TW}
       />
     </Layout>
   );
 };
 
-export const getServerSideProps: GetServerSideProps<Omit<CommunityBoardPropType, 'texts'>> = async (
-  context
-) => {
+export const getServerSideProps: GetServerSideProps<
+  Omit<CommunityMyPostPropType, 'texts'>
+> = async (context) => {
   // const cookies = nookies.get(context);
   // const userId = cookies['user_id'];
   const userId = '1a11a56286d1c02c5eb4f38b6d6fa0f5d2db490e0783d70f1b0db7746c96d1cc';
@@ -32,8 +28,8 @@ export const getServerSideProps: GetServerSideProps<Omit<CommunityBoardPropType,
   const boardIndex = parseInt(context.query.boardIndex as string);
   const page = parseInt(context.query.page as string) - 1 || 0;
   const lang = 'zhtw';
-  const boardLang = translateFrontLangToBackLang(context.query.boardLang as LangCookie) || 'ALL';
-  const topic = parseInt(context.query.topic as string) || '';
+  const boardLang = 'ALL';
+  const topic = '';
   const view_type = 'my_post';
 
   if (!boardIndex) return { notFound: true };

--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -273,6 +273,8 @@ export const CommunityMainText_ENG: CommunityPageTextType = {
   search: 'Search',
   recentlyBoards: 'Recently Visited Board',
   recommendedBoards: 'Recommended for you',
+  noRecentBoardTexts: ['Are you new to FanPlus?', 'Search for your favorite star!'],
+  buttonSearch: 'Search',
 };
 export const CommunityBoardText_ENG: CommunityBoardTextType = {
   all: 'All',
@@ -301,4 +303,7 @@ export const CommunityBoardText_ENG: CommunityBoardTextType = {
     id: 'Bahasa Indonesia',
     zhtw: '中文(繁體)',
   },
+  noPostTexts: ['There is no post.', 'Write a first post.'],
+  noMyPostTexts: ['There is no post.'],
+  buttonWrite: 'Write',
 };

--- a/src/texts/es.ts
+++ b/src/texts/es.ts
@@ -273,6 +273,8 @@ export const CommunityMainText_ESP: CommunityPageTextType = {
   search: 'Search',
   recentlyBoards: 'Visita reciente',
   recommendedBoards: 'Recomendación',
+  noRecentBoardTexts: ['¿Eres nuevo en FanPlus?', '¡Busca tu estrella favorita!'],
+  buttonSearch: 'Buscar',
 };
 export const CommunityBoardText_ESP: CommunityBoardTextType = {
   all: 'Total',
@@ -301,4 +303,7 @@ export const CommunityBoardText_ESP: CommunityBoardTextType = {
     id: 'Bahasa Indonesia',
     zhtw: '中文(繁體)',
   },
+  noPostTexts: ['No hay ninguna publicación.', 'Sé el primero en dejar una publicación.'],
+  noMyPostTexts: ['No hay publicaciones escritas.'],
+  buttonWrite: 'Escribir',
 };

--- a/src/texts/in.ts
+++ b/src/texts/in.ts
@@ -273,6 +273,12 @@ export const CommunityMainText_IND: CommunityPageTextType = {
   search: 'Cari',
   recentlyBoards: 'Papan Baru-Baru Ini Dikunjungi',
   recommendedBoards: 'Disarankan untuk Anda',
+  noRecentBoardTexts: [
+    'Apakah ini pertama kalinya',
+    'Anda menggunakan Fan Plus?',
+    'Cari bintang favoritmu!',
+  ],
+  buttonSearch: 'Cari',
 };
 export const CommunityBoardText_IND: CommunityBoardTextType = {
   all: 'Semua',
@@ -301,4 +307,7 @@ export const CommunityBoardText_IND: CommunityBoardTextType = {
     id: 'Bahasa Indonesia',
     zhtw: '中文(繁體)',
   },
+  noPostTexts: ['Tidak ada postingan', 'Jadilah orang pertama', 'yang meninggalkan postingan'],
+  noMyPostTexts: ['Tidak ada postingan yang ditulis'],
+  buttonWrite: 'Tulis',
 };

--- a/src/texts/ja.ts
+++ b/src/texts/ja.ts
@@ -273,6 +273,8 @@ export const CommunityMainText_JAP: CommunityPageTextType = {
   search: '掲示板検索',
   recentlyBoards: '最近訪れた掲示板',
   recommendedBoards: 'おすすめ掲示板',
+  noRecentBoardTexts: ['ファンプラスを利用するのは初めてですか?', 'お気に入りのスターを探せ！'],
+  buttonSearch: '検索',
 };
 export const CommunityBoardText_JAP: CommunityBoardTextType = {
   all: '全',
@@ -301,4 +303,7 @@ export const CommunityBoardText_JAP: CommunityBoardTextType = {
     id: 'Bahasa Indonesia',
     zhtw: '中文(繁體)',
   },
+  noPostTexts: ['投稿はありません', '最初に投稿を残してください'],
+  noMyPostTexts: ['書かれた投稿はありません'],
+  buttonWrite: '書き込み',
 };

--- a/src/texts/ko.ts
+++ b/src/texts/ko.ts
@@ -274,6 +274,8 @@ export const CommunityMainText_KR: CommunityPageTextType = {
   search: '게시판 검색',
   recentlyBoards: '최근 방문한 게시판',
   recommendedBoards: '추천 게시판',
+  noRecentBoardTexts: ['팬플러스는 처음 사용하시나요?', '좋아하는 스타를 검색해 보세요!'],
+  buttonSearch: '검색하기',
 };
 export const CommunityBoardText_KR: CommunityBoardTextType = {
   all: '전체',
@@ -302,4 +304,7 @@ export const CommunityBoardText_KR: CommunityBoardTextType = {
     id: 'Bahasa Indonesia',
     zhtw: '中文(繁體)',
   },
+  noPostTexts: ['게시글이 없습니다.', '제일 먼저 게시글을 남겨주세요.'],
+  noMyPostTexts: ['작성된 글이 없습니다.'],
+  buttonWrite: '글쓰기',
 };

--- a/src/texts/vi.ts
+++ b/src/texts/vi.ts
@@ -273,6 +273,12 @@ export const CommunityMainText_VIE: CommunityPageTextType = {
   search: 'Tìm kiếm',
   recentlyBoards: 'Ban đã ghé thăm gần đây',
   recommendedBoards: 'Được đề xuất cho của bạn',
+  noRecentBoardTexts: [
+    'Đây có phải là lần đầu tiên',
+    'bạn sử dụng Fan Plus?',
+    'Hãy tìm kiếm ngôi sao yêu thích của bạn!',
+  ],
+  buttonSearch: 'Tìm kiếm',
 };
 export const CommunityBoardText_VIE: CommunityBoardTextType = {
   all: 'Tất cả',
@@ -301,4 +307,7 @@ export const CommunityBoardText_VIE: CommunityBoardTextType = {
     id: 'Bahasa Indonesia',
     zhtw: '中文(繁體)',
   },
+  noPostTexts: ['Không có bài viết nào', 'Hãy là người đầu tiên để lại bài viết'],
+  noMyPostTexts: ['Không có bài viết nào được viết'],
+  buttonWrite: 'Viết',
 };

--- a/src/texts/zh-CN.ts
+++ b/src/texts/zh-CN.ts
@@ -273,6 +273,8 @@ export const CommunityMainText_zh_CN: CommunityPageTextType = {
   search: '搜索消息面板',
   recentlyBoards: '最近浏览的消息面板',
   recommendedBoards: '推荐的消息面板',
+  noRecentBoardTexts: ['您是FanPlus新手吗？', '搜索你最喜欢的明星！'],
+  buttonSearch: '搜索',
 };
 export const CommunityBoardText_zh_CN: CommunityBoardTextType = {
   all: '全部',
@@ -301,4 +303,7 @@ export const CommunityBoardText_zh_CN: CommunityBoardTextType = {
     id: 'Bahasa Indonesia',
     zhtw: '中文(繁體)',
   },
+  noPostTexts: ['没有帖子。', '成为第一个发表帖子的人'],
+  noMyPostTexts: ['没有帖子。'],
+  buttonWrite: '发帖子',
 };

--- a/src/texts/zh-TW.ts
+++ b/src/texts/zh-TW.ts
@@ -273,6 +273,8 @@ export const CommunityMainText_zh_TW: CommunityPageTextType = {
   search: '搜索消息面板',
   recentlyBoards: '最近瀏覽的消息面板',
   recommendedBoards: '推薦的消息面板',
+  noRecentBoardTexts: ['您是FanPlus新手嗎？', '搜索你最喜歡的明星！'],
+  buttonSearch: '搜索',
 };
 export const CommunityBoardText_zh_TW: CommunityBoardTextType = {
   all: '全部',
@@ -301,4 +303,7 @@ export const CommunityBoardText_zh_TW: CommunityBoardTextType = {
     id: 'Bahasa Indonesia',
     zhtw: '中文(繁體)',
   },
+  noPostTexts: ['沒有帖子。', '成為第一個發表帖子的人'],
+  noMyPostTexts: ['沒有帖子。'],
+  buttonWrite: '發帖子',
 };

--- a/src/types/textTypes.ts
+++ b/src/types/textTypes.ts
@@ -166,6 +166,8 @@ export type CommunityPageTextType = {
   search: string;
   recentlyBoards: string;
   recommendedBoards: string;
+  noRecentBoardTexts: string[];
+  buttonSearch: string;
 };
 export type CommunityBoardTextType = {
   all: string;
@@ -194,6 +196,9 @@ export type CommunityBoardTextType = {
     id: string;
     zhtw: string;
   };
+  noPostTexts: string[];
+  noMyPostTexts: string[];
+  buttonWrite: string;
 };
 
 export type TextType = {


### PR DESCRIPTION
이제 남은 작업은
1. 글쓰기 버튼 클릭시 글쓰기 에디터 페이지로 이동시키기 기능
2. 현재 totalPost 개수를 200개로 임의로 설정 중인데 api에서 totalCount 값을 받아오면 로직 수정 예정 (및 기본값을 1로하여 글이 없는 경우 1페이지가 노출될 수 있도록 할 예정)
3. 현재 userId 가 있어야 api를 호출하는데, 없을 경우도 로직 추가할 예정
4. 알림 기능 (논의 더 필요합니다)