### PR TITLE
[develop] voteDetail 페이지에서 각 커뮤니티 게시판으로 가는 버튼 생성

### DIFF
--- a/src/components/atoms/CommunityButton.tsx
+++ b/src/components/atoms/CommunityButton.tsx
@@ -1,0 +1,24 @@
+import { HTMLAttributes } from 'react';
+import { UnstyledButton } from './UnstyledButton';
+
+export interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {}
+
+export function CommunityButton({ ...props }: ButtonProps) {
+  return (
+    <UnstyledButton
+      css={{
+        padding: '7px 16px',
+        fontSize: 17,
+        fontWeight: 600,
+        borderRadius: 20,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: '#343A40',
+        border: '1px solid #101010',
+        transition: '0.3s ease-in-out',
+      }}
+      {...props}
+    />
+  );
+}

--- a/src/components/atoms/ShareButton.tsx
+++ b/src/components/atoms/ShareButton.tsx
@@ -15,7 +15,7 @@ function ShareButton({ ...props }: Props) {
       <img
         src="/icons/icon_share.svg"
         alt="icon_share"
-        css={{ padding: 8, verticalAlign: 'middle' }}
+        css={{ padding: 6, verticalAlign: 'middle' }}
       />
     </UnstyledButton>
   );

--- a/src/components/organisms/voteDetail/VoteDetailList.tsx
+++ b/src/components/organisms/voteDetail/VoteDetailList.tsx
@@ -10,7 +10,7 @@ import { useEffect, useRef } from 'react';
 
 export interface VoteDetailListProps {
   voteDetailStars: VoteDetailStars[];
-  communityOnClick: (boardIndex: number) => void;
+  communityOnClick: (boardIndex: string) => void;
   shareOnClick: (id: string) => void;
   voteOnClick: (id: string) => void;
   scrollTargetId?: string;
@@ -47,13 +47,18 @@ function VoteDetailList({
       </Stack>
       <Stack spacing={0} justify="flex-start" css={{ backgroundColor: '#fff' }}>
         {voteDetailStars.map((item, index) => {
+          const board_IDX =
+            item.BOARD_LIST.length === 1
+              ? item.BOARD_LIST[0].BOARD_IDX
+              : item.BOARD_LIST[1].BOARD_IDX;
+
           return (
             <div key={item.STAR_IDX}>
               <VoteDetailListItem
                 starData={item}
                 starState={<VoteStarState starData={item} />}
                 clickEvent={{
-                  communityOnClick: () => communityOnClick(91), // TODO: 해당 게시판으로 이동 해주시면 됩니당 (현재 getVoteDetail api의 리스폰스에 board Index 값이 없음)
+                  communityOnClick: () => communityOnClick(board_IDX),
                   shareOnClick: () => shareOnClick(item.STAR_IDX),
                   voteOnClick: () => voteOnClick(item.STAR_IDX),
                 }}

--- a/src/components/organisms/voteDetail/VoteDetailList.tsx
+++ b/src/components/organisms/voteDetail/VoteDetailList.tsx
@@ -10,6 +10,7 @@ import { useEffect, useRef } from 'react';
 
 export interface VoteDetailListProps {
   voteDetailStars: VoteDetailStars[];
+  communityOnClick: (boardIndex: number) => void;
   shareOnClick: (id: string) => void;
   voteOnClick: (id: string) => void;
   scrollTargetId?: string;
@@ -18,6 +19,7 @@ export interface VoteDetailListProps {
 
 function VoteDetailList({
   voteDetailStars,
+  communityOnClick,
   shareOnClick,
   voteOnClick,
   scrollTargetId,
@@ -51,6 +53,7 @@ function VoteDetailList({
                 starData={item}
                 starState={<VoteStarState starData={item} />}
                 clickEvent={{
+                  communityOnClick: () => communityOnClick(91), // TODO: 해당 게시판으로 이동 해주시면 됩니당 (현재 getVoteDetail api의 리스폰스에 board Index 값이 없음)
                   shareOnClick: () => shareOnClick(item.STAR_IDX),
                   voteOnClick: () => voteOnClick(item.STAR_IDX),
                 }}

--- a/src/components/organisms/voteDetail/VoteDetailListItem.tsx
+++ b/src/components/organisms/voteDetail/VoteDetailListItem.tsx
@@ -6,13 +6,14 @@ import { useUrlLanguage } from '@/hooks/useLanguage';
 import { useRecoilState } from 'recoil';
 import { voteDetailLangState } from '@/store/voteLangState';
 import { Cookies } from 'react-cookie';
+import { CommunityButton } from '@/components/atoms/CommunityButton';
 
 const cookies = new Cookies();
 
 export interface PromotionRankListItemProps {
   starData: VoteDetailStars;
   starState: React.ReactNode;
-  clickEvent: { shareOnClick: () => void; voteOnClick: () => void };
+  clickEvent: { communityOnClick: () => void; shareOnClick: () => void; voteOnClick: () => void };
   targetRef?: React.RefObject<HTMLDivElement>;
 }
 
@@ -32,6 +33,9 @@ function VoteDetailListItem({
         {starState}
         <Group spacing={8} position="right">
           <ShareButton onClick={clickEvent.shareOnClick} />
+          <CommunityButton onClick={clickEvent.communityOnClick}>
+            {voteDetailLanguage?.board}
+          </CommunityButton>
           <VoteButton onClick={clickEvent.voteOnClick}>{voteDetailLanguage?.voting}</VoteButton>
         </Group>
       </Stack>

--- a/src/components/templates/VoteDetailLayout.tsx
+++ b/src/components/templates/VoteDetailLayout.tsx
@@ -218,6 +218,10 @@ const VoteDetailLayout = ({
     setShareModalIsOpened(true);
   };
 
+  const communityOnClick = (boardIndex: number) => {
+    router.push(`/${language}/community/board/${boardIndex}/`);
+  };
+
   const voteOnClick = async (id: string) => {
     const stars = voteDetails.RESULTS.DATAS.VOTE_INFO.STARS;
     const starIndex = stars.findIndex((star) => star.STAR_IDX === id);
@@ -260,6 +264,7 @@ const VoteDetailLayout = ({
 
   const voteDetailListProps: VoteDetailListProps = {
     voteDetailStars: voteDetails.RESULTS.DATAS.VOTE_INFO.STARS,
+    communityOnClick,
     shareOnClick,
     voteOnClick,
     scrollTargetId: typeof router.query.id === 'string' ? router.query.id : '',

--- a/src/components/templates/VoteDetailLayout.tsx
+++ b/src/components/templates/VoteDetailLayout.tsx
@@ -218,7 +218,7 @@ const VoteDetailLayout = ({
     setShareModalIsOpened(true);
   };
 
-  const communityOnClick = (boardIndex: number) => {
+  const communityOnClick = (boardIndex: string) => {
     router.push(`/${language}/community/board/${boardIndex}/`);
   };
 

--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -194,6 +194,7 @@ export const Votes_Text_en = {
 export const VoteDetail_Text_en = {
   vote: 'Vote',
   voting: 'Vote',
+  board: 'Board',
   voteResult: 'Result',
   voteDifference: {
     front: 'Winning by',

--- a/src/texts/es.ts
+++ b/src/texts/es.ts
@@ -194,6 +194,7 @@ export const Votes_Text_es = {
 export const VoteDetail_Text_es = {
   vote: 'Votación',
   voting: 'Votar',
+  board: 'Tablero',
   voteResult: 'Resultado',
   voteDifference: {
     front: '¡Diferencia de',

--- a/src/texts/in.ts
+++ b/src/texts/in.ts
@@ -194,6 +194,7 @@ export const Votes_Text_in = {
 export const VoteDetail_Text_in = {
   vote: 'Pemungutan suara',
   voting: 'Beri suara',
+  board: 'Papan',
   voteResult: 'Hasil',
   voteDifference: {
     front: 'Beda',

--- a/src/texts/ja.ts
+++ b/src/texts/ja.ts
@@ -194,6 +194,7 @@ export const Votes_Text_ja = {
 export const VoteDetail_Text_ja = {
   vote: '投票',
   voting: '投票する',
+  board: '掲示板',
   voteResult: '投票結果',
   voteDifference: {
     front: null,

--- a/src/texts/ko.ts
+++ b/src/texts/ko.ts
@@ -195,6 +195,7 @@ export const Votes_Text_ko = {
 export const VoteDetail_Text_ko = {
   vote: '투표',
   voting: '투표하기',
+  board: '게시판',
   voteResult: '투표 결과',
   voteDifference: {
     front: null,

--- a/src/texts/vi.ts
+++ b/src/texts/vi.ts
@@ -194,6 +194,7 @@ export const Votes_Text_vi = {
 export const VoteDetail_Text_vi = {
   vote: 'Bỏ phiếu',
   voting: 'Bỏ phiếu',
+  board: 'Board',
   voteResult: 'Kết quả',
   voteDifference: {
     front: null,

--- a/src/texts/zh-CN.ts
+++ b/src/texts/zh-CN.ts
@@ -194,6 +194,7 @@ export const Votes_Text_zh = {
 export const VoteDetail_Text_zh = {
   vote: '投票',
   voting: '投票',
+  board: '消息面板',
   voteResult: '投票结果',
   voteDifference: {
     front: null,

--- a/src/texts/zh-TW.ts
+++ b/src/texts/zh-TW.ts
@@ -194,6 +194,7 @@ export const Votes_Text_zhtw = {
 export const VoteDetail_Text_zhtw = {
   vote: '投票',
   voting: '投票',
+  board: '消息面板',
   voteResult: '投票結果',
   voteDifference: {
     front: null,

--- a/src/types/vote.ts
+++ b/src/types/vote.ts
@@ -73,6 +73,11 @@ export interface VoteDetailStars {
   STAR_NAME: string;
   STAR_DEFAULT_PHOTO: string;
   STAR_GROUP_NAME: string;
+  BOARD_LIST: VoteDetailStarBoardList[];
+}
+
+export interface VoteDetailStarBoardList {
+  BOARD_IDX: string;
 }
 
 export interface VoteDetailResponse {


### PR DESCRIPTION
string 작업 및 버튼까지는 다 만들어 놨습니당
현재 getVoteDetail api 의 response 값으로 게시판 인덱스가 없어서 그 부분만 작업해주시면 될 것 같습니다.

요약하면,
1. api response type 수정: VoteDetailStars 에 BOARD_IDX: number (혹은 string) 추가
2. VoteDetailList 컴포넌트의 56번 줄 communityOnClick(91) -> communityOnClick(item.BOARD_IDX)로 수정
* number가 아닌 string일 경우 VoteDetailLayout 컴포넌트의 221번 줄
const communityOnClick = (boardIndex: number) => { // } 부분을
const communityOnClick = (boardIndex: string) =>  { // } 으로 타입 변환 있겠습니다.!

api 참고: https://fanmaum-dev.postman.co/workspace/%25ED%258C%25AC%25ED%2594%258C%25EB%259F%25AC%25EC%258A%25A4-%25ED%2594%2584%25EB%25A1%259C%25EC%25A0%259D%25ED%258A%25B8~0345f189-150e-41e9-8d91-3db5f938414b/request/4323496-6d7f2c6e-56dc-4fc1-b892-21c249849cb1

기획서 참고: https://www.figma.com/file/WrAUWfLY7qRqDjJCndUVUP/%ED%8C%AC%ED%94%8C%EB%9F%AC%EC%8A%A4-(Hybrid)?type=design&node-id=346-6218&mode=design&t=r61Gt4tyMxHckYzG-0