### PR TITLE
[master] 게시글 업로드 관련

### DIFF
--- a/src/pages/api/community/post.ts
+++ b/src/pages/api/community/post.ts
@@ -24,3 +24,11 @@ const handler: NextApiHandler = async (req, res) => {
 };
 
 export default handler;
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '10mb',
+    },
+  },
+};

--- a/src/pages/api/community/post.ts
+++ b/src/pages/api/community/post.ts
@@ -28,7 +28,7 @@ export default handler;
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: '10mb',
+      sizeLimit: '50mb',
     },
   },
 };

--- a/src/pages/api/community/postBoardArticle.ts
+++ b/src/pages/api/community/postBoardArticle.ts
@@ -43,7 +43,7 @@ export default handler;
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: '10mb',
+      sizeLimit: '50mb',
     },
   },
 };

--- a/src/pages/api/community/postBoardArticle.ts
+++ b/src/pages/api/community/postBoardArticle.ts
@@ -39,3 +39,11 @@ const handler: NextApiHandler = async (req, res) => {
 };
 
 export default handler;
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '10mb',
+    },
+  },
+};


### PR DESCRIPTION
이미지 복붙 등을 통한 게시의 경우 게시글 자체의 사이즈가 커져 기본 설정인 1mb을 초과
-> 최대 50mb로 수정