### PR TITLE
[develop] PostEditorTemplate 컴포넌트 렌더링 최적화

### DIFF
--- a/src/components/templates/PostEditorTemplate.tsx
+++ b/src/components/templates/PostEditorTemplate.tsx
@@ -1,6 +1,6 @@
 import { editBoardArticle, postBoardArticle, uploadEditorFile } from '@/api/Community';
-import { imagesUploadHandler } from '@/editor/util/imagesUploadHandler';
 import FullEditor from '@/editor/screen/FullEditor';
+import { imagesUploadHandler } from '@/editor/util/imagesUploadHandler';
 import { communityPostEditorTexts } from '@/texts/communityPostEditorTexts';
 import type { ServerLangType, UrlLangType } from '@/types/common';
 import type { TopicListItemType } from '@/types/community';
@@ -75,6 +75,8 @@ const PostEditorTemplate = ({ mode, urlLang, topics, datas, defaultValues }: Own
 
   const onClickUpload: MouseEventHandler = (event) => {
     event.preventDefault();
+    const content = editorRef?.current?.get(editorId)?.getContent() || '';
+    setContent(content);
     if (!title || !content) {
       setDataLackModal(true);
       return;
@@ -150,7 +152,7 @@ const PostEditorTemplate = ({ mode, urlLang, topics, datas, defaultValues }: Own
         </StyledBar>
         <StyledBar>
           <h2>{texts.title}</h2>
-          <TitleInput placeholder={texts.titlePlaceholder} title={title} setTitle={setTitle} />
+          <TitleInput placeholder={texts.titlePlaceholder} setTitle={setTitle} />
         </StyledBar>
         <StyledBar>
           <h2>{texts.content}</h2>
@@ -158,8 +160,7 @@ const PostEditorTemplate = ({ mode, urlLang, topics, datas, defaultValues }: Own
         <FullEditor
           editorRef={editorRef}
           editorId={editorId}
-          setContent={setContent}
-          defaultValue={content}
+          defaultValue={defaultValues?.content}
           language={urlLang}
           uppyFileUploadHandler={uppyFileUploadHandler}
           imagesUploadHandler={imagesUploadHandler(userId, appendAttachmentIds, postIndex)}
@@ -217,11 +218,9 @@ const StyledBar = ({ children }: { children: ReactNode }) => {
 
 const TitleInput = ({
   placeholder,
-  title,
   setTitle,
 }: {
   placeholder: string;
-  title?: string;
   setTitle: Dispatch<SetStateAction<string>>;
 }) => {
   return (
@@ -238,8 +237,7 @@ const TitleInput = ({
         '::placeholder': { color: '#d9d9d9', fontSize: '16px' },
       }}
       placeholder={placeholder}
-      value={title}
-      onChange={(e) => setTitle(e.target.value)}
+      onBlur={(e) => setTitle(e.target.value)}
     />
   );
 };

--- a/src/components/templates/PostEditorTemplate.tsx
+++ b/src/components/templates/PostEditorTemplate.tsx
@@ -152,7 +152,11 @@ const PostEditorTemplate = ({ mode, urlLang, topics, datas, defaultValues }: Own
         </StyledBar>
         <StyledBar>
           <h2>{texts.title}</h2>
-          <TitleInput placeholder={texts.titlePlaceholder} setTitle={setTitle} />
+          <TitleInput
+            placeholder={texts.titlePlaceholder}
+            defaultValue={defaultValues?.title}
+            setTitle={setTitle}
+          />
         </StyledBar>
         <StyledBar>
           <h2>{texts.content}</h2>
@@ -218,9 +222,11 @@ const StyledBar = ({ children }: { children: ReactNode }) => {
 
 const TitleInput = ({
   placeholder,
+  defaultValue,
   setTitle,
 }: {
   placeholder: string;
+  defaultValue?: string;
   setTitle: Dispatch<SetStateAction<string>>;
 }) => {
   return (
@@ -237,6 +243,7 @@ const TitleInput = ({
         '::placeholder': { color: '#d9d9d9', fontSize: '16px' },
       }}
       placeholder={placeholder}
+      defaultValue={defaultValue}
       onBlur={(e) => setTitle(e.target.value)}
     />
   );

--- a/src/editor/screen/FullEditor.tsx
+++ b/src/editor/screen/FullEditor.tsx
@@ -1,6 +1,6 @@
 import type { UrlLangType } from '@/types/common';
 import Script from 'next/script';
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Editor } from '../../../public/tinymce/tinymce';
 import {
   useCustomImageButton,
@@ -14,22 +14,20 @@ import { useTinyMCEConfig } from '../module/useTinyMCEConfig';
 type TProps = {
   editorRef: any;
   editorId: string;
-  setContent: Dispatch<SetStateAction<any>>;
   defaultValue?: string;
   language: UrlLangType;
   uppyFileUploadHandler: (file: any) => Promise<void>;
   imagesUploadHandler: (blobInfo: any) => Promise<string | undefined>;
 };
 
-const FullEditor: React.FC<TProps> = ({
+const FullEditor = ({
   editorRef,
   editorId,
-  setContent,
   defaultValue,
   language,
   uppyFileUploadHandler,
   imagesUploadHandler,
-}) => {
+}: TProps) => {
   const [isJsLoading, setIsJsLoading] = useState(true);
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -49,12 +47,10 @@ const FullEditor: React.FC<TProps> = ({
     editorRef.current.init({
       ...useTinyMCEConfig(language),
       selector: `#${editorId}`,
-      init_instance_callback: () => editorLoadedComplete(),
+      init_instance_callback: editorLoadedComplete,
       images_upload_handler: imagesUploadHandler,
 
       setup: (editor: Editor) => {
-        editor.on('change', () => setContent(editor.getContent()));
-        editor.on('keyup', () => setContent(editor.getContent()));
         useIOSIMESetting(editor);
 
         const onCustomAction = () => setModalOpen(true);


### PR DESCRIPTION
현재 에디터: 제목 및 내용이 변경될때마다 리렌더링 되고 있음.
변경점
 - 제목의 경우: onBlur 이벤트 발동시 set
 - content의 경우: 글쓰기 버튼을 클릭했을 때 set